### PR TITLE
Fix UEFI boot issues

### DIFF
--- a/elements/reinstall-grub-efi/finalise.d/60-reinstall-grub-efi
+++ b/elements/reinstall-grub-efi/finalise.d/60-reinstall-grub-efi
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+BOOT_DEV=$IMAGE_BLOCK_DEVICE
+echo "Re-installing grub"
+/usr/sbin/grub-install '--modules=part_msdos part_gpt lvm' --target=x86_64-efi "$BOOT_DEV" || :

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -8,5 +8,17 @@ export DIB_GRUB_INSTALLTYPE=both
 export DIB_DISTRIBUTION_MIRROR=http://archive.ubuntu.com/ubuntu/
 export IMG=ubuntu24.04-uefi-legacy-new.qcow2
 export DIB_BASE_IMAGE_URL=https://cloud-images.ubuntu.com/noble/current/ubuntu-noble-server-cloudimg-amd64-disk-kernel.img
+export DIB_CLOUD_INIT_DATASOURCES="ConfigDrive,NoCloud,None"
+export DIB_BLOCK_DEVICE=efi
+export ELEMENTS_PATH=./elements
 
-disk-image-create ubuntu vm block-device-efi dhcp-all-interfaces bootloader grub2 -o $IMG -p linux-firmware,cloud-init
+disk-image-create \
+  ubuntu \
+  vm \
+  block-device-efi \
+  dhcp-all-interfaces \
+  bootloader \
+  grub2 \
+  cloud-init-datasources \
+  reinstall-grub-efi \
+  -o $IMG -p linux-firmware,cloud-init


### PR DESCRIPTION
This adds a custom element to re-run grub-install without the
`--removeable` option, which causes it to correctly populate the
`/boot/efi/EFI/ubuntu` directory. This results in an image that will boot
successfully on UEFI systems.

You will run into an issue testing this image in a virtual machine: when
the image first boots, it immediately resets during the early UEFI boot
process. This will require you to `virsh start` the image, which will work
fine but will not attach cloud-init metadata you defined with the
`--cloud-init` option so you won't be able to log in.

Consider using `virt-customize` to set a root password before testing the
image.
